### PR TITLE
Polish intake dialog UX and fix Supabase submission

### DIFF
--- a/app/founder-led/FormWizard.jsx
+++ b/app/founder-led/FormWizard.jsx
@@ -12,15 +12,40 @@ const initialAnswers = {
 };
 
 const stepConfig = [
-  { key: "name", label: "Your name", type: "text", placeholder: "e.g., Suresh Malani" },
-  { key: "email", label: "Work email", type: "email", placeholder: "you@company.com" },
-  { key: "phone", label: "Phone / WhatsApp (with country code)", type: "text", placeholder: "+91 98xxxxxxx" },
-  { key: "instagramUrl", label: "Main Instagram profile", type: "text", placeholder: "@yourhandle or profile URL" },
+  {
+    key: "name",
+    label: "What's your name?",
+    helper: "We'll use it so our team knows who to reach out to.",
+    type: "text",
+    placeholder: "e.g., Suresh Malani",
+  },
+  {
+    key: "email",
+    label: "Work email",
+    helper: "This is where we'll send your tailored growth plan.",
+    type: "email",
+    placeholder: "you@company.com",
+  },
+  {
+    key: "phone",
+    label: "Phone / WhatsApp",
+    helper: "Include your country code so we can connect without delays.",
+    type: "text",
+    placeholder: "+91 98xxxxxxx",
+  },
+  {
+    key: "instagramUrl",
+    label: "Main Instagram profile",
+    helper: "Share your handle or a link so we can review your content.",
+    type: "text",
+    placeholder: "@yourhandle or profile URL",
+  },
   {
     key: "investment",
     label: "Monthly investment you can commit",
+    helper: "Pick the range that best reflects your current budget.",
     type: "radio",
-    options: ["< $500", "$500 - $1000", "$1000 - $5000", "> $5000"],
+    options: ["Under $500", "$500 – $1,000", "$1,000 – $5,000", "$5,000+"],
   },
 ];
 
@@ -99,12 +124,13 @@ export default function FormWizard({ onClose, onQualified }) {
     setSaving(true);
     setError(null);
 
-    const tier =
-      answers.investment === "< $500"
-        ? "none"
-        : answers.investment === "$500 to $1000"
-          ? "basic"
-          : "full";
+    const tierMap = {
+      "Under $500": "none",
+      "$500 – $1,000": "basic",
+      "$1,000 – $5,000": "full",
+      "$5,000+": "full",
+    };
+    const tier = tierMap[answers.investment] ?? "none";
 
     try {
       if (!supabase || typeof supabase.from !== "function") {
@@ -155,7 +181,15 @@ export default function FormWizard({ onClose, onQualified }) {
       return (
         <div className="mt-6 space-y-3">
           {currentStep.options.map((option) => (
-            <label key={option} className="flex cursor-pointer items-center gap-3 rounded-2xl px-4 py-3">
+            <label
+              key={option}
+              className={`flex cursor-pointer items-center justify-between rounded-2xl border px-4 py-3 transition ${
+                answers[currentStep.key] === option
+                  ? "border-indigo-400/70 bg-indigo-500/15 text-white"
+                  : "border-white/10 bg-white/5 text-slate-200 hover:border-indigo-400/40"
+              }`}
+            >
+              <span className="text-base font-medium">{option}</span>
               <input
                 type="radio"
                 name={currentStep.key}
@@ -163,7 +197,6 @@ export default function FormWizard({ onClose, onQualified }) {
                 onChange={() => updateAnswer(currentStep.key, option)}
                 className="h-4 w-4 accent-indigo-500"
               />
-              <span className="text-lg">{option}</span>
             </label>
           ))}
         </div>
@@ -208,7 +241,7 @@ export default function FormWizard({ onClose, onQualified }) {
                 rel="noopener noreferrer"
                 className="inline-block bg-emerald-500 text-slate-950 font-bold py-3 px-8 rounded-lg text-lg hover:bg-emerald-400 transition-shadow shadow-[0_0_25px_rgba(16,185,129,0.3)] uppercase"
               >
-                BOOK a call
+                Apply now
               </a>
             )}
             {copy.showReset && (
@@ -237,7 +270,10 @@ export default function FormWizard({ onClose, onQualified }) {
         <div className="mb-2 text-sm text-slate-400">
           Step {step + 1} of {totalSteps}
         </div>
-        <h3 className="text-2xl font-semibold text-slate-100">{currentStep.label}</h3>
+        <h3 className="text-3xl font-semibold text-white">{currentStep.label}</h3>
+        {currentStep.helper ? (
+          <p className="mt-2 max-w-xl text-base text-slate-300/80">{currentStep.helper}</p>
+        ) : null}
         {renderField()}
 
         <div className="mt-8 flex items-center justify-between text-sm text-slate-300">

--- a/app/founder-led/page.jsx
+++ b/app/founder-led/page.jsx
@@ -226,7 +226,7 @@ function Hero({ onAuditClick }) {
               onClick={onAuditClick}
               className="inline-flex flex-col items-center gap-1 rounded-full bg-white px-6 py-4 text-base font-semibold text-[#0a0f1a] transition hover:bg-white/90"
             >
-              <span>Book a 10-minute Audit</span>
+              <span>Apply now</span>
               <span className="text-sm font-medium text-[#0a0f1a]/70">→ We’ll set your custom reach target</span>
             </button>
             <p className="text-xs font-medium uppercase tracking-wide text-emerald-200/80">
@@ -475,7 +475,7 @@ function AuditCTA({ onAuditClick, qualifiedLead }) {
             onClick={onAuditClick}
             className="inline-flex flex-col items-center gap-1 rounded-full bg-white px-6 py-4 text-base font-semibold text-[#0a0f1a] transition hover:bg-white/90"
           >
-            <span>Book a 10-minute Audit</span>
+            <span>Apply now</span>
             <span className="text-sm font-medium text-[#0a0f1a]/70">→ We’ll set your custom reach target</span>
           </button>
           <span className="text-xs font-medium uppercase tracking-wide text-emerald-200/80">

--- a/app/globals.css
+++ b/app/globals.css
@@ -36,8 +36,27 @@ body {
 .card.fullscreen { width: 100%; max-width: 100%; height: 100vh; border-radius: 0; display: flex; align-items: center; justify-content: center; flex-direction: column; padding: 80px 40px; gap: 24px; box-sizing: border-box; }
 .result-container { max-width: 720px; width: 100%; }
 
-.form-input { padding: 14px; background: rgba(0, 0, 0, 0.4); border: 1px solid rgba(255,255,255,0.2); border-radius: 8px; color: white; font-size: 1.1rem; outline: none; transition: border-color 0.3s, box-shadow 0.3s; }
-.form-input:focus { border-color: #42a5f5; box-shadow: 0 0 10px rgba(66,165,245,0.5); }
+.form-input {
+  width: 100%;
+  margin-top: 1.5rem;
+  padding: 0.9rem 1.1rem;
+  background: rgba(12, 21, 44, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 1rem;
+  color: #f8fafc;
+  font-size: 1.05rem;
+  outline: none;
+  transition: border-color 0.25s ease, box-shadow 0.25s ease, background 0.25s ease;
+  backdrop-filter: blur(12px);
+}
+.form-input::placeholder {
+  color: rgba(203, 213, 225, 0.75);
+}
+.form-input:focus {
+  border-color: rgba(96, 165, 250, 0.8);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.18);
+  background: rgba(18, 31, 65, 0.8);
+}
 
 .calendly-link { display: inline-block; padding: 12px 25px; margin-top: 1rem; background-color: #4caf50; color: white; text-decoration: none; font-weight: bold; border-radius: 5px; transition: background-color 0.3s ease; }
 .calendly-link:hover { background-color: #45a049; }

--- a/app/pb/FormWizardPB.jsx
+++ b/app/pb/FormWizardPB.jsx
@@ -13,15 +13,40 @@ const initialAnswers = {
 };
 
 const stepConfig = [
-  { key: "name", label: "Your name", type: "text", placeholder: "e.g., Suresh Malani" },
-  { key: "email", label: "Work email", type: "email", placeholder: "you@company.com" },
-  { key: "phone", label: "Phone / WhatsApp (with country code)", type: "text", placeholder: "+91 98xxxxxxx" },
-  { key: "instagramUrl", label: "Main Instagram profile", type: "text", placeholder: "@yourhandle or profile URL" },
+  {
+    key: "name",
+    label: "What's your name?",
+    helper: "We love knowing who we're speaking with.",
+    type: "text",
+    placeholder: "e.g., Suresh Malani",
+  },
+  {
+    key: "email",
+    label: "Work email",
+    helper: "We'll share your personalised content roadmap here.",
+    type: "email",
+    placeholder: "you@company.com",
+  },
+  {
+    key: "phone",
+    label: "Phone / WhatsApp",
+    helper: "Include your country code so we can reach you easily.",
+    type: "text",
+    placeholder: "+91 98xxxxxxx",
+  },
+  {
+    key: "instagramUrl",
+    label: "Main Instagram profile",
+    helper: "Drop your @handle or a link—we'll review it before the call.",
+    type: "text",
+    placeholder: "@yourhandle or profile URL",
+  },
   {
     key: "investment",
     label: "Monthly investment you can commit",
+    helper: "Choose the tier that reflects your growth budget right now.",
     type: "radio",
-    options: ["< $500", "$500 to $1000", "$1000 to $5000", "> $5000"],
+    options: ["Under $500", "$500 – $1,000", "$1,000 – $5,000", "$5,000+"],
   },
 ];
 
@@ -103,21 +128,26 @@ export default function FormWizardPB({ onClose, onQualified }) {
     setSaving(true);
     setError(null);
 
-    const tier =
-      answers.investment === "< $500"
-        ? "none"
-        : answers.investment === "$500 to $1000"
-          ? "basic"
-          : "full";
+    const tierMap = {
+      "Under $500": "none",
+      "$500 – $1,000": "basic",
+      "$1,000 – $5,000": "full",
+      "$5,000+": "full",
+    };
+    const tier = tierMap[answers.investment] ?? "none";
 
     try {
+      if (!supabase || typeof supabase.from !== "function") {
+        throw new Error("Supabase client is not configured");
+      }
+
       const { error: insertError } = await supabase
         .from("submissions")
         .insert({
           name: answers.name,
           email: answers.email,
           phone: answers.phone,
-          instagramurl: answers.instagramUrl,
+          instagram_url: answers.instagramUrl,
           investment: answers.investment,
         });
 
@@ -162,11 +192,13 @@ export default function FormWizardPB({ onClose, onQualified }) {
           {currentStep.options.map((option) => (
             <label
               key={option}
-              className={`group flex items-center justify-between rounded-2xl border border-white/10 bg-white/5 px-4 py-3 text-base text-white/80 backdrop-blur transition ${
-                answers[currentStep.key] === option ? "border-indigo-400/60 bg-indigo-400/10 text-white" : "hover:border-white/30"
+              className={`group flex items-center justify-between rounded-2xl border px-4 py-3 text-base backdrop-blur transition ${
+                answers[currentStep.key] === option
+                  ? "border-indigo-400/70 bg-indigo-500/15 text-white"
+                  : "border-white/10 bg-white/5 text-white/85 hover:border-indigo-300/40"
               }`}
             >
-              <span>{option}</span>
+              <span className="font-medium">{option}</span>
               <input
                 type="radio"
                 name={currentStep.key}
@@ -184,7 +216,7 @@ export default function FormWizardPB({ onClose, onQualified }) {
       <input
         ref={inputRef}
         autoFocus
-        className="mt-6 w-full rounded-2xl border border-white/15 bg-white/5 px-4 py-3 text-base text-white outline-none backdrop-blur transition focus:border-indigo-400 focus:bg-white/10"
+        className="mt-6 w-full rounded-2xl border border-white/15 bg-white/5 px-4 py-3 text-base text-white outline-none backdrop-blur transition focus:border-indigo-300 focus:bg-white/10"
         type={currentStep.type}
         placeholder={currentStep.placeholder}
         value={answers[currentStep.key]}
@@ -213,7 +245,7 @@ export default function FormWizardPB({ onClose, onQualified }) {
                 rel="noopener noreferrer"
                 className="pb-result-cta"
               >
-                Book a Call on Calendly
+                Apply now
               </a>
             )}
             {state.secondary && (
@@ -245,6 +277,7 @@ export default function FormWizardPB({ onClose, onQualified }) {
       >
         <div className="pb-step">Step {step + 1} of {totalSteps}</div>
         <h3 className="pb-question">{currentStep.label}</h3>
+        {currentStep.helper ? <p className="pb-helper">{currentStep.helper}</p> : null}
         {renderField()}
 
         <div className="pb-actions">

--- a/app/pb/page.jsx
+++ b/app/pb/page.jsx
@@ -226,7 +226,7 @@ function Hero({ onAuditClick }) {
               onClick={onAuditClick}
               className="inline-flex flex-col items-center gap-1 rounded-full bg-white px-6 py-4 text-base font-semibold text-[#0a0f1a] transition hover:bg-white/90"
             >
-              <span>Book a 10-minute Audit</span>
+              <span>Apply now</span>
               <span className="text-sm font-medium text-[#0a0f1a]/70">→ We’ll set your custom reach target</span>
             </button>
             <p className="text-xs font-medium uppercase tracking-wide text-emerald-200/80">
@@ -475,7 +475,7 @@ function AuditCTA({ onAuditClick, qualifiedLead }) {
             onClick={onAuditClick}
             className="inline-flex flex-col items-center gap-1 rounded-full bg-white px-6 py-4 text-base font-semibold text-[#0a0f1a] transition hover:bg-white/90"
           >
-            <span>Book a 10-minute Audit</span>
+            <span>Apply now</span>
             <span className="text-sm font-medium text-[#0a0f1a]/70">→ We’ll set your custom reach target</span>
           </button>
           <span className="text-xs font-medium uppercase tracking-wide text-emerald-200/80">

--- a/app/pb/pb.css
+++ b/app/pb/pb.css
@@ -90,6 +90,14 @@
   font-weight: 700;
 }
 
+.pb-helper {
+  margin-top: 0.75rem;
+  max-width: 30rem;
+  font-size: 1rem;
+  color: rgba(203, 213, 225, 0.8);
+  line-height: 1.6;
+}
+
 .pb-actions {
   margin-top: 2.5rem;
   display: flex;


### PR DESCRIPTION
## Summary
- add helper copy and refreshed styling to the intake dialog for clearer, friendlier guidance
- align Supabase submission payloads and tier mapping so the final step can save responses reliably
- rename the primary call-to-action buttons to “Apply now” for consistency across the funnel

## Testing
- not run (needs local ESLint configuration)

------
https://chatgpt.com/codex/tasks/task_e_68d7e568300c832bb03782a612a35b2e